### PR TITLE
Ubuntu 18.04 non GA kernel required - Documentation update (#10)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,8 @@ To contribute, fork the repository and create a branch in your fork for your wor
 ### Environment
 * `Linux` OS (dev team is using Ubuntu 18.04)
   * Development can be done on Windows Subsystem for Linux, but Procmon cannot be executed in that environment
+  * To execute Procmon you need `kernel` >= 4.18 and <= 5.3. Those are *not* Ubuntu 18.04 GA kernels,
+  please refer to [install instructions](INSTALL.md) for more info.
 * `git`
 * `cmake` >= 3.14
 * `libsqlite3-dev` >= 3.22

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -13,3 +13,17 @@ sudo apt-get update
 sudo apt-get install procmon
 ```
 
+#### 3. Install updated Linux kernel
+Minimum Linux kernel version to run `Procmon` is 4.18 that is *not* shipped with Ubuntu 18.04 GA.
+To use version 4.18 or newer you can:
+
+1. Use Ubuntu HWE kernel (See [here]( https://wiki.ubuntu.com/Kernel/LTSEnablementStack) for reference) or
+
+2. Use a tool like `ukuu`, for example:
+    ```sh
+    sudo apt-get install gdebi
+    wget https://github.com/teejee2008/ukuu/releases/download/v18.9.1/ukuu-v18.9.1-amd64.deb
+    sudo gdebi ukuu-v18.9.1-amd64.deb 
+    sudo ukuu --install v4.18
+    ```
+


### PR DESCRIPTION
@MarioHewardt - Update docs on kernel requirements with instruction to install Ubuntu 18.04 alternative kernels.