### PR TITLE
Use Xterm control sequence to hide/show the cursor

### DIFF
--- a/src/procmon.cpp
+++ b/src/procmon.cpp
@@ -25,7 +25,7 @@ int main(int argc, char *argv[])
     * This is due to a conflict that leads to the consumer thread dieing when the system
     * function is executed.
     */
-    system("setterm -cursor off");
+    std::cout << "\33[?25l";
 
     // Configure logging
     el::Loggers::addFlag(el::LoggingFlag::HierarchicalLogging);
@@ -77,7 +77,7 @@ int main(int argc, char *argv[])
     }
 
     // re-enable cursor before exiting Procmon
-    system("setterm -cursor on");
+    std::cout << "\33[?12l\33[?25h";
 
     return 0;
 }

--- a/src/procmon.cpp
+++ b/src/procmon.cpp
@@ -25,7 +25,7 @@ int main(int argc, char *argv[])
     * This is due to a conflict that leads to the consumer thread dieing when the system
     * function is executed.
     */
-    std::cout << "\33[?25l";
+    curs_set(0);
 
     // Configure logging
     el::Loggers::addFlag(el::LoggingFlag::HierarchicalLogging);
@@ -77,7 +77,7 @@ int main(int argc, char *argv[])
     }
 
     // re-enable cursor before exiting Procmon
-    std::cout << "\33[?12l\33[?25h";
+    curs_set(1);
 
     return 0;
 }


### PR DESCRIPTION
Instead of invoking `setterm` command to turn on/off cursor visibility, it's just better to use Xterm control sequences. Some very older terminals might not support this sequence but the majority of it does. 